### PR TITLE
Fix type `NSURL` to `URL` of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ struct MyServiceRequest<Batch: JSONRPCKit.Batch>: APIKit.Request {
     typealias Response = Batch.Responses
 
     var baseURL: URL {
-        return NSURL(string: "https://api.example.com/")!
+        return URL(string: "https://api.example.com/")!
     }
 
     var method: HTTPMethod {


### PR DESCRIPTION
Thank you for your great OSS in beforehand.
I fixed a type should be migrated to swift4 in README.md.