### PR TITLE
Use new version of Result lib (5.0.0)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "7477584259bfce2560a19e06ad9f71db441fff11",
-          "version": "3.2.4"
+          "revision": "12920a5c2595926efab9274d6003e29f503dbb66",
+          "version": "5.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "JSONRPCKit", targets: ["JSONRPCKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/antitypical/Result.git", from: "3.2.0"),
+        .package(url: "https://github.com/antitypical/Result.git", from: "5.0.0"),
     ],
     targets: [
         .target(name: "JSONRPCKit", dependencies: ["Result"]),


### PR DESCRIPTION
**Problem**

Unable to build JSONRPCKit with Xcode 12, error log:
```
➜  JSONRPCKit git:(master) swift build
Fetching https://github.com/antitypical/Result.git
error: because no versions of Result match the requirement 3.2.6..<4.0.0 and Result 1.0.2..<3.2.6 contains incompatible tools version, Result 1.0.2..<4.0.0 is forbidden.
And because root depends on Result 3.2.0..<4.0.0, version solving failed.
```

**How it was tested**
After this update, run `swift test` locally:

```
➜  JSONRPCKit git:(master) ✗ swift test
[5/5] Linking JSONRPCKitPackageTests
Test Suite 'All tests' started at 2020-08-29 15:16:00.118
Test Suite 'JSONRPCKitPackageTests.xctest' started at 2020-08-29 15:16:00.119
Test Suite 'BatchElementTests' started at 2020-08-29 15:16:00.119
Test Case '-[JSONRPCKitTests.BatchElementTests testNotificationRequestObject]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testNotificationRequestObject]' passed (0.052 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testRequestObject]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testRequestObject]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArray]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArray]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayErrorObjectParseError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayErrorObjectParseError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArraymissingBothResultAndError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArraymissingBothResultAndError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayResponseError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayResponseError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayresponseNotFound]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayresponseNotFound]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayresultObjectParseError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayresultObjectParseError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayunsupportedVersion]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromArrayunsupportedVersion]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObject]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObject]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectErrorObjectParseError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectErrorObjectParseError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectmissingBothResultAndError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectmissingBothResultAndError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectResponseError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectResponseError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectresponseNotFound]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectresponseNotFound]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectresultObjectParseError]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectresultObjectParseError]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectunsupportedVersion]' started.
Test Case '-[JSONRPCKitTests.BatchElementTests testResponseFromObjectunsupportedVersion]' passed (0.000 seconds).
Test Suite 'BatchElementTests' passed at 2020-08-29 15:16:00.176.
	 Executed 16 tests, with 0 failures (0 unexpected) in 0.056 (0.057) seconds
Test Suite 'BatchFactoryTests' started at 2020-08-29 15:16:00.176
Test Case '-[JSONRPCKitTests.BatchFactoryTests test1]' started.
Test Case '-[JSONRPCKitTests.BatchFactoryTests test1]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchFactoryTests test2]' started.
Test Case '-[JSONRPCKitTests.BatchFactoryTests test2]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchFactoryTests test3]' started.
Test Case '-[JSONRPCKitTests.BatchFactoryTests test3]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchFactoryTests test4]' started.
Test Case '-[JSONRPCKitTests.BatchFactoryTests test4]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchFactoryTests test5]' started.
Test Case '-[JSONRPCKitTests.BatchFactoryTests test5]' passed (0.000 seconds).
Test Case '-[JSONRPCKitTests.BatchFactoryTests testThreadSafety]' started.
Test Case '-[JSONRPCKitTests.BatchFactoryTests testThreadSafety]' passed (0.065 seconds).
Test Suite 'BatchFactoryTests' passed at 2020-08-29 15:16:00.242.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.066 (0.066) seconds
Test Suite 'JSONRPCKitPackageTests.xctest' passed at 2020-08-29 15:16:00.242.
	 Executed 22 tests, with 0 failures (0 unexpected) in 0.122 (0.123) seconds
Test Suite 'All tests' passed at 2020-08-29 15:16:00.242.
	 Executed 22 tests, with 0 failures (0 unexpected) in 0.122 (0.124) seconds
```
